### PR TITLE
Remove dependence on script tag dataset

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
 	"module": "dist/whc.modern.js",
 	"source": "src/index.js",
 	"scripts": {
-		"start": "rm -rf build && microbundle watch --compress false -f modern,umd --no-sourcemap --raw=true",
-		"build": "rm -rf build && microbundle -f modern,umd --no-sourcemap",
+		"start": "microbundle watch --compress false -f modern,umd --no-sourcemap --raw=true",
 		"pack:src": "microbundle --compress false -f umd,modern --no-sourcemap",
 		"pack:dist:umd": "microbundle -i src/index.js -o dist/min/whc.min.js -f umd --no-sourcemap --name WHC",
 		"pack:dist:modern": "microbundle -i src/index.js -o dist/min/whc.min.js -f modern --no-sourcemap --name WHC",

--- a/src/includes/get-data.js
+++ b/src/includes/get-data.js
@@ -1,0 +1,18 @@
+export default function getData(form) {
+	if (!form.hasAttribute('id')) throw Error('Form is missing ID attribute');
+
+	const data = {
+		button: form.querySelector('[type="submit"]'),
+		difficulty: parseInt(form.dataset.difficulty) || 5,
+		debug: 'debug' in form.dataset,
+		eventName: 'WHC|' + form.getAttribute('id'),
+	};
+
+	// prettier-ignore
+	if ('button' in form.dataset && (data.button === null || data.button === undefined)) {
+		// prettier-ignore
+		data.button = document.querySelector('[form="' + form.getAttribute('id') + '"][type="submit"]');
+	}
+
+	return data;
+}

--- a/src/includes/get-data.js
+++ b/src/includes/get-data.js
@@ -6,6 +6,7 @@ export default function getData(form) {
 		difficulty: parseInt(form.dataset.difficulty) || 5,
 		debug: 'debug' in form.dataset,
 		eventName: 'WHC|' + form.getAttribute('id'),
+		finished: 'finished' in form.dataset ? form.dataset.finished : 'Submit',
 	};
 
 	// prettier-ignore

--- a/src/index.html
+++ b/src/index.html
@@ -3,34 +3,29 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Document</title>
+		<title>WHC Form Test</title>
 	</head>
 	<body>
-		<form action="" id="formOne" class="whc-form" data-debug="1">
-			<input
-				type="submit"
-				value="verifying"
-				disabled
-				data-finished="verified"
-				class="whc-button"
-				data-difficulty="1"
-			/>
+		<form
+			action=""
+			id="formOne"
+			data-whc
+			data-debug
+			data-finished="Verified"
+			data-difficulty="1"
+		>
+			<input type="submit" value="verifying" disabled />
 		</form>
-		<form action="" id="formTwo" class="whc-form" data-debug="1">
-			<input
-				type="submit"
-				value="verifying"
-				disabled
-				data-finished="verified"
-				class="whc-button"
-				data-difficulty="1"
-			/>
+		<form
+			action=""
+			id="formTwo"
+			data-whc
+			data-debug
+			data-finished="submit"
+			data-difficulty="1"
+		>
+			<input type="submit" value="verifying" disabled />
 		</form>
-		<script
-			src="../dist/whc.umd.js"
-			id="whcScriptTag"
-			data-form="whc-form"
-			data-button="whc-button"
-		></script>
+		<script async defer src="../dist/whc.umd.js"></script>
 	</body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,6 @@
 import worker from './includes/worker';
 
 (function () {
-	const script = document.getElementById('whcScriptTag');
-
-	const forms = Array.from(
-		document.getElementsByClassName(script.dataset.form),
-	);
-
 	var Constructor = function (form, index) {
 		// now converted to seconds
 		const eventName = 'WHC|' + (form.getAttribute('id') || 'Form ' + index),
@@ -127,5 +121,7 @@ import worker from './includes/worker';
 		emit('Constructed');
 	};
 
-	forms.forEach((form, i) => new Constructor(form, i));
+	document
+		.querySelectorAll('[data-whc]')
+		.forEach((form, i) => new Constructor(form, i));
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ import getData from './includes/get-data';
 			try {
 				var blob = new Blob(
 					// generates a worker by converting  into a string and then running that function as a worker
-					['(' + worker.toString() + ')();'],
+					[`(${worker})();`],
 					{ type: 'application/javascript' },
 				);
 				var url = window.URL || window.webkitURL;

--- a/src/index.js
+++ b/src/index.js
@@ -7,14 +7,20 @@ import getData from './includes/get-data';
 
 (function () {
 	var Constructor = function (form) {
-		const { eventName, button, difficulty, debug } = getData(form);
+		const data = getData(form),
+			debug = data.debug,
+			button = data.button,
+			difficulty = data.difficulty,
+			eventName = data.eventName,
+			finished = data.finished;
 
 		var emit = function () {};
 		if (debug) {
 			window.addEventListener(
 				eventName,
-				({ detail }) =>
-					console.log(eventName + '::Message -> ' + detail),
+				function (e) {
+					console.log(eventName + '::Message -> ' + e.detail);
+				},
 				true,
 			);
 			emit = function (detail) {
@@ -54,9 +60,8 @@ import getData from './includes/get-data';
 			sendRequest('https://wehatecaptchas.com/api.php').then(function (
 				data,
 			) {
-				const { question } = data.data;
 				internalWorker.postMessage({
-					question: question,
+					question: data.data.question,
 					time: Math.floor(Date.now() / 1000),
 					difficulty: difficulty,
 				});
@@ -66,7 +71,7 @@ import getData from './includes/get-data';
 		};
 
 		var sendRequest = async function (url) {
-			var formData = new FormData();
+			let formData = new FormData();
 
 			formData.append('endpoint', 'question');
 
@@ -80,7 +85,8 @@ import getData from './includes/get-data';
 			return data;
 		};
 
-		var workerMessageHandler = function ({ data }) {
+		var workerMessageHandler = function (response) {
+			const data = response.data;
 			if (data.action === 'captchaSuccess') {
 				form.insertAdjacentHTML(
 					'beforeend',
@@ -91,7 +97,7 @@ import getData from './includes/get-data';
 
 				button.classList.add('done');
 				button.disabled = false;
-				button.value = button.dataset.finished;
+				button.value = finished;
 
 				return;
 			} else if (data.action === 'message') {

--- a/src/index.js
+++ b/src/index.js
@@ -3,21 +3,14 @@
  * (c) 2020 Exceleron Designs, MIT License, https://excelerondesigns.com
  */
 import worker from './includes/worker';
+import getData from './includes/get-data';
 
 (function () {
-	var Constructor = function (form, index) {
-		// now converted to seconds
-		const eventName = 'WHC|' + (form.getAttribute('id') || 'Form ' + index),
-			// should be a class selector
-			// each button should also have a 'data-finished' text that the button should end on
-			// This defaults to a search of the whole document,
-			button =
-				form.getElementsByClassName(script.dataset.button)[0] ||
-				document.getElementsByClassName(script.dataset.button)[0],
-			difficulty = parseInt(button.dataset.difficulty) || 5;
+	var Constructor = function (form) {
+		const { eventName, button, difficulty, debug } = getData(form);
 
 		var emit = function () {};
-		if ('debug' in form.dataset) {
+		if (debug) {
 			window.addEventListener(
 				eventName,
 				({ detail }) =>
@@ -123,5 +116,5 @@ import worker from './includes/worker';
 
 	document
 		.querySelectorAll('[data-whc]')
-		.forEach((form, i) => new Constructor(form, i));
+		.forEach((form) => new Constructor(form));
 })();


### PR DESCRIPTION
## Goal

Add settings on the form elements instead of the script tag.

### Process

Instead there would be each form element would have `data-whc` identifying it.

__Benefits__

- Allows each form to have its own settings.
- Opens up the possibility of using `form` attribute on `<fieldset>` and `<input type="submit">` elements.